### PR TITLE
fix(deps): remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   ],
   "author": "Philipp Kursawe <pke@pke.fyi> (https://pke.fyi/)",
   "license": "MIT",
-  "peerDependencies": {
-    "date-fns": "~2.0.0"
-  },
   "devDependencies": {
     "chai": "4.2.0",
     "eslint": "6.8.0",
@@ -29,6 +26,6 @@
     "jest": "26.6.3"
   },
   "dependencies": {
-    "date-fns": "2.8.1"
+    "date-fns": "^2.8.1"
   }
 }


### PR DESCRIPTION
`date-fns` is set as both a dependency and a peerDependency. It should be one or the other.
In addition, the specified versions are incompatible (~2.0.0 is not compatible with 2.8.1)